### PR TITLE
Fix the documentation links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![GitHub release](https://img.shields.io/github/release/cybozu-go/netutil.svg?maxAge=60)][releases]
 ![CI](https://github.com/cybozu-go/netutil/workflows/CI/badge.svg)
-[![Go Reference](https://pkg.go.dev/badge/cybozu-go/netutil.svg)](https://pkg.go.dev/cybozu-go/netutil)
+[![Go Reference](https://pkg.go.dev/badge/cybozu-go/netutil.svg)](https://pkg.go.dev/github.com/cybozu-go/netutil)
 [![Go Report Card](https://goreportcard.com/badge/github.com/cybozu-go/netutil)](https://goreportcard.com/report/github.com/cybozu-go/netutil)
 
 Add-ons for networking
@@ -21,7 +21,7 @@ Features
 Usage
 -----
 
-Read [the documentation](https://pkg.go.dev/cybozu-go/netutil).
+Read [the documentation](https://pkg.go.dev/github.com/cybozu-go/netutil).
 
 License
 -------


### PR DESCRIPTION
The original link to the _Go Reference_ is 404. I fixed the documentation links.